### PR TITLE
Remove files for unwatched roots

### DIFF
--- a/lib/core/watcher.js
+++ b/lib/core/watcher.js
@@ -158,6 +158,13 @@ export default class Watcher {
     this._chokidar.unwatch(path);
 
     this._roots = this._roots.filter(p => p !== path);
+
+    for (const file of this._files) {
+
+      if (file.startsWith(path)) {
+        this._removeFile(file);
+      }
+    }
   }
 
   close() {

--- a/lib/core/watcher.js
+++ b/lib/core/watcher.js
@@ -45,19 +45,11 @@ export default class Watcher {
         return;
       }
 
-      this._files.add(path);
-
-      this._emit('add', pathToFileURL(path).toString());
-
-      this._changed();
+      this._addFile(path);
     });
 
     this._chokidar.on('unlink', path => {
-      this._emit('remove', pathToFileURL(path).toString());
-
-      this._files.delete(path);
-
-      this._changed();
+      this._removeFile(path);
     });
 
     if (/\*|events/.test(process.env.DEBUG || '')) {
@@ -78,6 +70,28 @@ export default class Watcher {
       this.removeFolder(uri);
     });
 
+  }
+
+  /**
+   * @param {string} path
+   */
+  _removeFile(path) {
+    this._emit('remove', pathToFileURL(path).toString());
+
+    this._files.delete(path);
+
+    this._changed();
+  }
+
+  /**
+   * @param { string } path
+   */
+  _addFile(path) {
+    this._files.add(path);
+
+    this._emit('add', pathToFileURL(path).toString());
+
+    this._changed();
   }
 
   /**

--- a/test/spec/core/watcher.spec.js
+++ b/test/spec/core/watcher.spec.js
@@ -33,6 +33,23 @@ describe('core/watcher', function() {
     expect(watcher.getFiles()).to.have.length(4);
   });
 
+
+  it('should unwatch directory', async function() {
+
+    // given
+    watcher.addFolder(fileUri('test/fixtures/notes'));
+
+    await on('watcher:ready', eventBus);
+
+    // when
+    watcher.removeFolder(fileUri('test/fixtures/notes'));
+
+    await on('watcher:changed', eventBus);
+
+    // then
+    expect(watcher.getFiles()).to.be.empty;
+  });
+
 });
 
 


### PR DESCRIPTION
This ensures we clear the index from unwanted files, when a root is removed, i.e. because a workspace (LSP) got closed.