### PR TITLE
Keep locally opened files post unwatching

### DIFF
--- a/lib/core/indexer.js
+++ b/lib/core/indexer.js
@@ -111,10 +111,11 @@ export default class Indexer {
     }
 
     if (localValue) {
-      indexItem.value = localValue;
+      indexItem.value = indexItem.localValue = localValue;
       indexItem._read = () => Promise.resolve(indexItem);
     } else {
       indexItem._read = undefined;
+      indexItem.global = true;
     }
 
     indexItem._process = undefined;
@@ -175,12 +176,20 @@ export default class Indexer {
     }
 
     if (local) {
-      item.value = undefined;
+      item.value = item.localValue = undefined;
 
       item._read = undefined;
       item._process = undefined;
 
-      return this._parseItem(item);
+      if (item.global) {
+        return this._parseItem(item);
+      }
+    } else {
+      if (item.localValue) {
+        item.global = false;
+
+        return this._parseItem(item);
+      }
     }
 
     this.items.delete(uri);
@@ -299,14 +308,14 @@ export default class Indexer {
    *
    * @param { string } uri
    *
-   * @return { Promise<ParsedIndexItem | null> }
+   * @return { Promise<ParsedIndexItem | undefined> }
    */
   async get(uri) {
 
     const item = this.items.get(uri);
 
     if (!item) {
-      return null;
+      return undefined;
     }
 
     return this._parseItem(item);

--- a/test/spec/core/indexer.spec.js
+++ b/test/spec/core/indexer.spec.js
@@ -166,6 +166,62 @@ describe('core/indexer', function() {
   });
 
 
+  it('should keep local file after file indexing', async function() {
+
+    // given
+    const uri = fileUri('test/fixtures/notes/IDEAS.md');
+
+    await indexer.fileOpen({
+      uri,
+      value: 'FOO'
+    });
+
+    // when
+    const item = await indexer.add(uri);
+
+    // then
+    expect(item.value).to.eql('FOO');
+
+    expect(
+      indexer.getItems()
+    ).to.have.length(1);
+  });
+
+
+  it('should keep local file after removing globally indexed', async function() {
+
+    // given
+    const removedItems = [];
+
+    eventBus.on('indexer:removed', (item) => {
+      removedItems.push(item);
+    });
+
+    const uri = fileUri('test/fixtures/notes/IDEAS.md');
+
+    await indexer.fileOpen({
+      uri,
+      value: 'FOO'
+    });
+
+    const item = await indexer.add(uri);
+
+    // when
+    // removing global item
+    await indexer.remove(uri);
+
+    // then
+    // item still locally opened
+    expect(removedItems).to.be.empty;
+
+    // removing local item
+    await indexer.fileClosed(uri);
+
+    // then
+    expect(removedItems).to.eql([ item ]);
+  });
+
+
   function addFiles(paths) {
 
     for (const path of paths) {


### PR DESCRIPTION
This ensures that files, if locally opened, are still accounted for when their global representation is removed (i.e. because workspace got removed).